### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
 # X(Twitter) MCP server
 
+[![smithery badge](https://smithery.ai/badge/x-mcp)](https://smithery.ai/server/x-mcp)
+
 An MCP server to create, manage and publish X/Twitter posts directly through Claude chat.
 
 ## Quick Setup
 
+### Installing via Smithery
+
+To install X(Twitter) MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/x-mcp):
+
+```bash
+npx -y @smithery/cli install x-mcp --client claude
+```
+
+### Manual Installation
 1. Clone the repository:
 ```bash
 git clone https://github.com/yourusername/x-mcp.git


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install X(Twitter) MCP Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/x-mcp

Let me know if any tweaks have to be made!