### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An MCP server to create, manage and publish X/Twitter posts directly through Claude chat.
 
+<a href="https://glama.ai/mcp/servers/jsxr09dktf">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/jsxr09dktf/badge" alt="X(Twitter) Server MCP server" />
+</a>
+
 ## Quick Setup
 
 ### Installing via Smithery


### PR DESCRIPTION
This PR adds a badge for the [X(Twitter) MCP Server](https://glama.ai/mcp/servers/jsxr09dktf) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jsxr09dktf">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/jsxr09dktf/badge" alt="X(Twitter) Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.